### PR TITLE
Introducing "path" parameter for push

### DIFF
--- a/prometheus.bash
+++ b/prometheus.bash
@@ -588,9 +588,9 @@ io::prometheus::internal::PrintfError() {
 }
 
 io::prometheus::internal::Push() {
-  local method='' job='' instance='' gateway=''
+  local method='' job='' instance='' gateway='' path=''
   io::prometheus::internal::ParseDdStyleArgs "${FUNCNAME[1]}" \
-    'method' 'job' '~instance' 'gateway' -- "$@" || return
+    'method' 'job' '~instance' 'gateway' '~path' -- "$@" || return
 
   # Construct the URL to push to.
   local url
@@ -601,6 +601,9 @@ io::prometheus::internal::Push() {
   esac
   if [[ -n "${instance}" ]]; then
     url="${url}/instance/${instance}"
+  fi
+  if [[ -n "${path}" ]]; then
+    url="${url}/${path}"
   fi
   # Compose and transmit the metrics.
   io::prometheus::ExportAsText | curl -q \


### PR DESCRIPTION
This change introduces a new parameter `path`, which can be used like
```
io::prometheus::PushAdd job='jobname' instance='instancename' gateway=':9091' path='label1key/label1value/label2name/label2value'
```
resulting in a push URL like
http://localhost:9091/metrics/job/jobname/instance/instancename/label1key/label1value/label2name/label2value

Otherwise, if adding those labels directly to the metrics, they won't be appended to the `push_time_seconds` metric, which will result in a conflict if other jobs are pushing to the labeled path.