### PR TITLE
Allow gateway= to be expressed as https://host:port

### DIFF
--- a/prometheus.bash
+++ b/prometheus.bash
@@ -595,9 +595,10 @@ io::prometheus::internal::Push() {
   # Construct the URL to push to.
   local url
   case "${gateway}" in
-  :*)  url="http://localhost${gateway}/metrics/job/${job}";;
-  *:*) url="http://${gateway}/metrics/job/${job}";;
-  *)   url="http://${gateway}:9091/metrics/job/${job}"
+  http*)  url="${gateway}/metrics/job/${job}";;	  
+  :*)     url="http://localhost${gateway}/metrics/job/${job}";;
+  *:*)    url="http://${gateway}/metrics/job/${job}";;
+  *)      url="http://${gateway}:9091/metrics/job/${job}"
   esac
   if [[ -n "${instance}" ]]; then
     url="${url}/instance/${instance}"


### PR DESCRIPTION
I run the push gateway on kubernetes behind an internal ingress that does https by default, so I needed a way to define the gateway with the protocol, e.g. `https://host:port`